### PR TITLE
Link project cards to individual dialogs

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,7 +737,9 @@ main {
     <div class="swiper-wrapper">
       
         <div class="swiper-slide">
-          <div class="tech-border card js-card">
+          <div
+            class="tech-border card js-card"
+            >
             <div class="tech-border-internal">
               <div class="card-content">
                 
@@ -759,7 +761,9 @@ main {
         </div>
       
         <div class="swiper-slide">
-          <div class="tech-border card js-card">
+          <div
+            class="tech-border card js-card"
+            >
             <div class="tech-border-internal">
               <div class="card-content">
                 
@@ -781,7 +785,9 @@ main {
         </div>
       
         <div class="swiper-slide">
-          <div class="tech-border card js-card">
+          <div
+            class="tech-border card js-card"
+            >
             <div class="tech-border-internal">
               <div class="card-content">
                 
@@ -812,7 +818,9 @@ main {
     <div class="swiper-wrapper">
       
         <div class="swiper-slide">
-          <div class="tech-border card js-card">
+          <div
+            class="tech-border card js-card"
+            id="card-decathlon-usa" data-dialog-id="decathlon-usa">
             <div class="tech-border-internal">
               <div class="card-content">
                 
@@ -834,7 +842,9 @@ main {
         </div>
       
         <div class="swiper-slide">
-          <div class="tech-border card js-card">
+          <div
+            class="tech-border card js-card"
+            id="card-terracotta-arte-sacra" data-dialog-id="terracotta-arte-sacra">
             <div class="tech-border-internal">
               <div class="card-content">
                 
@@ -850,7 +860,9 @@ main {
         </div>
       
         <div class="swiper-slide">
-          <div class="tech-border card js-card">
+          <div
+            class="tech-border card js-card"
+            id="card-pedro-h-valladao" data-dialog-id="pedro-h-valladao">
             <div class="tech-border-internal">
               <div class="card-content">
                 
@@ -876,7 +888,7 @@ main {
 </main>
 
 
-  <dialog id="project-dialog">
+  <dialog class="project-dialog" id="dialog-decathlon-usa">
     <div class="tech-border">
       <div class="tech-border-internal">
         <h2>Decathlon USA</h2>
@@ -919,7 +931,7 @@ main {
     </div>
   </dialog>
 
-  <dialog id="project-dialog">
+  <dialog class="project-dialog" id="dialog-terracotta-arte-sacra">
     <div class="tech-border">
       <div class="tech-border-internal">
         <h2>TerraCotta Arte Sacra</h2>
@@ -938,7 +950,7 @@ main {
     </div>
   </dialog>
 
-  <dialog id="project-dialog">
+  <dialog class="project-dialog" id="dialog-pedro-h-valladao">
     <div class="tech-border">
       <div class="tech-border-internal">
         <h2>Pedro H Valladao</h2>
@@ -975,23 +987,25 @@ main {
           },
         });
 
-        /** @type {HTMLDialogElement|null} */
-        const dialog = document.getElementById('project-dialog');
-        const cards = document.querySelectorAll('.js-card');
+        /** @type {NodeListOf<HTMLDivElement>} */
+        const cards = document.querySelectorAll('#projects .js-card');
 
-        if (dialog) {
+        cards.forEach((card) => {
+          const dialogId = card.dataset.dialogId;
+          if (!dialogId) return;
+          const dialog = document.getElementById(`dialog-${dialogId}`);
+          if (!dialog) return;
+
           const closeBtn = dialog.querySelector('.close');
 
-          cards.forEach(card => {
-            card.addEventListener('click', () => {
-              if ('showModal' in dialog) dialog.showModal();
-            });
+          card.addEventListener('click', () => {
+            if ('showModal' in dialog) dialog.showModal();
           });
 
           closeBtn && closeBtn.addEventListener('click', () => {
             dialog.close();
           });
-        }
+        });
       });
     </script>
 

--- a/src/_data/projects.json
+++ b/src/_data/projects.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "decathlon-usa",
     "label": "Decathlon USA",
     "jobPosition": "Senior Shopify Web Developer",
     "items": [
@@ -27,10 +28,12 @@
     ]
   },
   {
+    "id": "terracotta-arte-sacra",
     "label": "TerraCotta Arte Sacra",
     "items": ["Full Stack System Development"]
   },
   {
+    "id": "pedro-h-valladao",
     "label": "Pedro H Valladao",
     "items": ["Composer Portfolio", "Next.js | TypeScript | Sanity.io"]
   }

--- a/src/_includes/cards.liquid
+++ b/src/_includes/cards.liquid
@@ -6,7 +6,9 @@
     <div class="swiper-wrapper">
       {% for card in cards %}
         <div class="swiper-slide">
-          <div class="tech-border card js-card">
+          <div
+            class="tech-border card js-card"
+            {% if card.id %}id="card-{{ card.id }}" data-dialog-id="{{ card.id }}"{% endif %}>
             <div class="tech-border-internal">
               <div class="card-content">
                 {% for item in card.items %}

--- a/src/_includes/dialog.liquid
+++ b/src/_includes/dialog.liquid
@@ -1,7 +1,7 @@
 {%- comment -%} Before release, remove these | include in project {%- endcomment -%}
 {%- comment %} theme-check-disable UndefinedObject {%- endcomment -%}
 {% for dialog in dialogs %}
-  <dialog id="project-dialog">
+  <dialog class="project-dialog" id="dialog-{{ dialog.id }}">
     <div class="tech-border">
       <div class="tech-border-internal">
         <h2>{{ dialog.label }}</h2>

--- a/src/_includes/layout.liquid
+++ b/src/_includes/layout.liquid
@@ -57,23 +57,25 @@
           },
         });
 
-        /** @type {HTMLDialogElement|null} */
-        const dialog = document.getElementById('project-dialog');
-        const cards = document.querySelectorAll('.js-card');
+        /** @type {NodeListOf<HTMLDivElement>} */
+        const cards = document.querySelectorAll('#projects .js-card');
 
-        if (dialog) {
+        cards.forEach((card) => {
+          const dialogId = card.dataset.dialogId;
+          if (!dialogId) return;
+          const dialog = document.getElementById(`dialog-${dialogId}`);
+          if (!dialog) return;
+
           const closeBtn = dialog.querySelector('.close');
 
-          cards.forEach(card => {
-            card.addEventListener('click', () => {
-              if ('showModal' in dialog) dialog.showModal();
-            });
+          card.addEventListener('click', () => {
+            if ('showModal' in dialog) dialog.showModal();
           });
 
           closeBtn && closeBtn.addEventListener('click', () => {
             dialog.close();
           });
-        }
+        });
       });
     </script>
 


### PR DESCRIPTION
## Summary
- add explicit `id` fields to each project in `projects.json`
- attach project ids to cards and dialogs for reliable matching
- open the correct dialog by looking up the id instead of relying on index order

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d06e2489c832e9d713dc7a8c8fb77